### PR TITLE
Added dependencies of RavenDB Embedded to fix weird dependency issue

### DIFF
--- a/BrickPile.UI.nuspec
+++ b/BrickPile.UI.nuspec
@@ -13,6 +13,12 @@
     <description>BrickPile is a lightweight CMS built on RavenDB and ASP.NET MVC 4</description>
 		<tags>brickpile cms ravendb mvc nosql</tags>
     <dependencies>
+      <dependency id="Microsoft.Data.Edm" version="[5.6.3]" />
+      <dependency id="Microsoft.Data.OData" version="[5.6.3]" />
+      <dependency id="Microsoft.Data.Services.Client" version="[5.6.3]" />
+      <dependency id="Microsoft.WindowsAzure.ConfigurationManager" version="[2.0.3]" />
+      <dependency id="System.Spatial" version="[5.6.3]" />
+      <dependency id="WindowsAzure.Storage" version="[4.3.0]" />
       <dependency id="RavenDB.Embedded" version="2.5.2700" />
       <dependency id="structuremap" version="2.6.4.1" />
       <dependency id="WebActivatorEX" version="2.0.1" />


### PR DESCRIPTION
When adding RavenDB,Embedded to an empty project, you'll get a weird dependency error saying: 
Install-Package : Updating 'System.Spatial 5.2.0' to 'System.Spatial 5.0.2' failed. Unable to find a version of 'RavenDB.Database' that is compatible with 'System.Spatial 5.0.2'.

To remedy this you need to add specific dependencies to the nuspec.
